### PR TITLE
Add a wait-for wrapper to wait up to 60s for tvheadend to start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,11 @@ FROM python:alpine
 RUN apk update && apk upgrade && \
     apk add --no-cache bash git openssh
 
-RUN git clone https://github.com/LukasdeBoer/horepg.git /horepg
+RUN git clone https://github.com/LukasdeBoer/horepg.git /horepg && \
+    git clone https://github.com/eficode/wait-for.git /waitfor && \
+    mv /waitfor/wait-for /usr/local/bin && \
+    rm -rf /waitfor
+
 WORKDIR /horepg
 RUN python setup.py install
 ADD entrypoint.sh /entrypoint.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-python horepgd.py -s /epggrab/xmltv.sock -tvh $TVH_HOST -tvh_username $TVH_USERNAME -tvh_password $TVH_PASSWORD -nr $NUM_DAYS
+/usr/local/bin/wait-for $TVH_HOST:${TVH_PORT:-9981} -t 60 -- python horepgd.py -s /epggrab/xmltv.sock -tvh $TVH_HOST -tvh_username $TVH_USERNAME -tvh_password $TVH_PASSWORD -nr $NUM_DAYS


### PR DESCRIPTION
When multiple containers for tvheadend, horepg, etc are started in parallel,
for example with docker-compose, horepg may start before tvheadend is listening
for http requests. In this situation the horepg container would exit.

Using 'depends on' ordering in docker-compose is not enough since the
container will not be immediately listening for http requests.

A wait-for script was added to wait up to 60s for tvheadend to respond.